### PR TITLE
Jumbotron font-size shrinks in smaller viewports.

### DIFF
--- a/dist/css/bootstrap-theme.css
+++ b/dist/css/bootstrap-theme.css
@@ -43,8 +43,31 @@ blockquote {
   text-align: center;
 }
 .jumbotron h1 {
-  font-size: 128px;
   line-height: 1em;
+  /* Small devices (tablets, 768px and up) */
+  /* Medium devices (desktops, 992px and up) */
+  /* Large devices (large desktops, 1200px and up) */
+}
+@media (min-width: 768px) {
+  .jumbotron h1 {
+    font-size: 64px;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    hyphens: auto;
+  }
+}
+@media (min-width: 992px) {
+  .jumbotron h1 {
+    font-size: 96px;
+  }
+}
+@media (min-width: 1200px) {
+  .jumbotron h1 {
+    font-size: 128px;
+  }
 }
 .jumbotron p {
   font-size: 32px;

--- a/src/layout.less
+++ b/src/layout.less
@@ -6,8 +6,27 @@ h1, h2, h3, h4, h5, h6, p, li, blockquote {
     text-align: center;
 
     h1 {
-        font-size: 128px;
         line-height: 1em;
+        /* Small devices (tablets, 768px and up) */
+        @media (min-width: @screen-sm-min) {
+            font-size: 64px;
+            -ms-word-break: break-all;
+            word-break: break-all;
+            word-break: break-word;
+            -webkit-hyphens: auto;
+            -moz-hyphens: auto;
+            hyphens: auto;
+        }
+
+        /* Medium devices (desktops, 992px and up) */
+        @media (min-width: @screen-md-min) {
+            font-size: 96px;
+        }
+
+        /* Large devices (large desktops, 1200px and up) */
+        @media (min-width: @screen-lg-min) {
+            font-size: 128px;
+        }
     }
 
     p {

--- a/src/theme.less
+++ b/src/theme.less
@@ -1,5 +1,6 @@
 @import 'lib/prefixer.less';
 @import 'colours.less';
+@import 'variables.less';
 @import 'layout.less';
 @import 'typography.less';
 @import 'nav.less';

--- a/src/variables.less
+++ b/src/variables.less
@@ -1,0 +1,42 @@
+//
+// Variables
+// --------------------------------------------------
+
+
+//== Media queries breakpoints
+//
+//## Define the breakpoints at which your layout will change, adapting to different screen sizes.
+
+// Extra small screen / phone
+//** Deprecated `@screen-xs` as of v3.0.1
+@screen-xs:                  480px;
+//** Deprecated `@screen-xs-min` as of v3.2.0
+@screen-xs-min:              @screen-xs;
+//** Deprecated `@screen-phone` as of v3.0.1
+@screen-phone:               @screen-xs-min;
+
+// Small screen / tablet
+//** Deprecated `@screen-sm` as of v3.0.1
+@screen-sm:                  768px;
+@screen-sm-min:              @screen-sm;
+//** Deprecated `@screen-tablet` as of v3.0.1
+@screen-tablet:              @screen-sm-min;
+
+// Medium screen / desktop
+//** Deprecated `@screen-md` as of v3.0.1
+@screen-md:                  992px;
+@screen-md-min:              @screen-md;
+//** Deprecated `@screen-desktop` as of v3.0.1
+@screen-desktop:             @screen-md-min;
+
+// Large screen / wide desktop
+//** Deprecated `@screen-lg` as of v3.0.1
+@screen-lg:                  1200px;
+@screen-lg-min:              @screen-lg;
+//** Deprecated `@screen-lg-desktop` as of v3.0.1
+@screen-lg-desktop:          @screen-lg-min;
+
+// So media queries don't overlap when required, provide a maximum
+@screen-xs-max:              (@screen-sm-min - 1);
+@screen-sm-max:              (@screen-md-min - 1);
+@screen-md-max:              (@screen-lg-min - 1);


### PR DESCRIPTION
Given the huge size of the default font, jumbotron h1 should shrink a little on smaller viewports, and break with hyphens when necessary.

This change is based on this tweet: https://twitter.com/iGARET/status/582593947240787968
